### PR TITLE
Issue 8: Update provisioner & snapshotter versions for 1.20+

### DIFF
--- a/.github/workflows/netappdocs-ci.yml
+++ b/.github/workflows/netappdocs-ci.yml
@@ -13,10 +13,14 @@ env:
   DEPLOY_HOST_PREVIEW: ${{ secrets.DEPLOY_HOST_PREVIEW }}
   GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  GH_DEPLOY: ${{ secrets.GH_DEPLOY }}
   MT_CLIENT: ${{ secrets.MT_CLIENT }}
   MT_SECRET: ${{ secrets.MT_SECRET }}
   MT_USER: ${{ secrets.MT_USER }}
   MT_PSWD: ${{ secrets.MT_PSWD }}
+  MAESTRO_USERNAME: ${{ secrets.MAESTRO_USERNAME }}
+  MAESTRO_PASSWORD: ${{ secrets.MAESTRO_PASSWORD }}
+
 
 jobs:
   build:

--- a/trident-get-started/requirements.adoc
+++ b/trident-get-started/requirements.adoc
@@ -148,10 +148,10 @@ a|
 a|
 * netapp/trident:22.04.0
 * netapp/trident-autosupport:22.04
-* k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+* k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
 * k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
 * k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
-* k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
+* k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
 * k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
 * netapp/trident-operator:22.04.0 (optional)
 
@@ -159,10 +159,10 @@ a|
 a|
 * netapp/trident:22.04.0
 * netapp/trident-autosupport:22.04
-* k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+* k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
 * k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
 * k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
-* k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
+* k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
 * k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
 * netapp/trident-operator:22.04.0 (optional)
 
@@ -170,10 +170,10 @@ a|
 a|
 * netapp/trident:22.04.0
 * netapp/trident-autosupport:22.04
-* k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+* k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
 * k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
 * k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
-* k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
+* k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
 * k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
 * netapp/trident-operator:22.04.0 (optional)
 
@@ -181,10 +181,10 @@ a|
 a|
 * netapp/trident:22.04.0
 * netapp/trident-autosupport:22.04
-* k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+* k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
 * k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
 * k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
-* k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
+* k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
 * k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
 * netapp/trident-operator:22.04.0 (optional)
 


### PR DESCRIPTION
Updated the provisioner & snapshotter versions for 1.20+.

*** k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0**

*** k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1**